### PR TITLE
fix: persistent data structures link in post

### DIFF
--- a/posts/persistent-data-structures.mdx
+++ b/posts/persistent-data-structures.mdx
@@ -376,6 +376,6 @@ I hope the above benchmarks speak for themselves. It's kind of funny because I e
 
 [Changelog](https://devblogs.microsoft.com/typescript/announcing-typescript-3-7-rc/#more-recursive-type-aliases)
 
-[Persistent data structures](<(https://en.wikipedia.org/wiki/Persistent_data_structure)>)
+[Persistent data structures](<https://en.wikipedia.org/wiki/Persistent_data_structure>)
 
 [Cons](https://en.wikipedia.org/wiki/Cons)


### PR DESCRIPTION
Loved the post! Fixed a link at the end there.

This is how it was before:
<img width="392" alt="image" src="https://user-images.githubusercontent.com/95541290/220141225-a13084c9-9512-4671-828f-73f52272c01b.png">
